### PR TITLE
Exercises 11.19

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check deployed service
         uses: jtalk/url-health-check-action@v4
         with:
-          url: https://your-app-url.com/health
+          url: https://full-stack-open-pokedex-or1w.onrender.com/health
           follow-redirect: true
           max-attempts: 3
           retry-delay: 10s

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,21 @@
+name: Periodic Health Check
+
+on:
+  # Manual trigger for testing
+  workflow_dispatch:
+
+  # Scheduled trigger: once every 24 hours at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ping-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check deployed service
+        uses: jtalk/url-health-check-action@v4
+        with:
+          url: https://your-app-url.com/health
+          follow-redirect: true
+          max-attempts: 3
+          retry-delay: 10s


### PR DESCRIPTION
chore(ci): add health check workflow

- Added periodic health check workflow
- Runs every 24 hours at midnight UTC
- Checks application health endpoint
- Uses jtalk/url-health-check-action